### PR TITLE
Add world download and upload as JSON

### DIFF
--- a/satisfactory-accounting-app/src/app.scss
+++ b/satisfactory-accounting-app/src/app.scss
@@ -190,6 +190,10 @@ input {
             box-sizing: border-box;
             padding: 5px;
             border-radius: 5px;
+
+            &.selected {
+                background-color: lighten(colors.$gray-light, 15%);
+            }
         }
 
         .database-list-row {
@@ -254,6 +258,12 @@ input {
 
         .delete-world {
             @include colors.red-button;
+        }
+
+        a.download-world {
+            @include colors.green-button;
+            text-decoration: none;
+            color: colors.$gray-dark;
         }
 
         .close {


### PR DESCRIPTION
Add buttons in the world selector for downloading and uploading worlds. 

I tested with a few large Worlds that I exported by hand from `LocalStorage` on the official GH site.

I did a secondary visual change too: the loaded world is displayed lighter and without the "Switch to this world" button. I changed the order of the buttons so that they don't re-shuffle when the load button is hidden.

I wasn't sure if I should refactor (de-duplicate) the pattern I copied from `Msg::CreateWorld`, so just let me know and I can fix that!

I am also a bit undecided about tacking on the ` (Uploaded)` label. I think it gives useful feedback about what just got uploaded and opened, but maybe it could be a timestamp instead of fixed string?

What do you think about a Clone button? Might try add that next. I can see a use for it for trying out big factory changes.

Thank you for making such a useful tool `:satisfactory-heart-hands:`

Fixes #7 